### PR TITLE
Add Num. actors parameter validation to run_local.sh

### DIFF
--- a/run_local.sh
+++ b/run_local.sh
@@ -24,6 +24,7 @@ AGENTS="r2d2|vtrace"
 [ "$#" -ne 0 ] || die "Usage: run_local.sh [$ENVIRONMENTS] [$AGENTS] [Num. actors]"
 echo $1 | grep -E -q $ENVIRONMENTS || die "Supported games: $ENVIRONMENTS"
 echo $2 | grep -E -q $AGENTS || die "Supported agents: $AGENTS"
+echo $3 | grep -E -q "^[0-9]+$" || die "Number of actors should be a non-negative integer"
 export ENVIRONMENT=$1
 export AGENT=$2
 export NUM_ACTORS=$3

--- a/run_local.sh
+++ b/run_local.sh
@@ -24,7 +24,7 @@ AGENTS="r2d2|vtrace"
 [ "$#" -ne 0 ] || die "Usage: run_local.sh [$ENVIRONMENTS] [$AGENTS] [Num. actors]"
 echo $1 | grep -E -q $ENVIRONMENTS || die "Supported games: $ENVIRONMENTS"
 echo $2 | grep -E -q $AGENTS || die "Supported agents: $AGENTS"
-echo $3 | grep -E -q "^[0-9]+$" || die "Number of actors should be a non-negative integer"
+echo $3 | grep -E -q "^((0|([1-9][0-9]*))|(0x[0-9a-fA-F]+))$" || die "Number of actors should be a non-negative integer without leading zeros"
 export ENVIRONMENT=$1
 export AGENT=$2
 export NUM_ACTORS=$3


### PR DESCRIPTION
+ Motivation `./run_local.sh football vtrace` starts normally (builds docker image, runs it, etc), then the error is shown on master-replica `FATAL Flags parsing error: flag --num_actors=: invalid literal for int() with base 10: ''`
+ Now `./run_local.sh football vtrace` ends with message `Number of actors should be a non-negative integer without leading zeros`
+ Regex explanations:
	- Why without leading zeros: bash can read `0010` as `8` but absl flags will read that as `10`
	- Why non-negative: because someone may want to run master without workers (debugging)