### PR TITLE
Fix GPG error due to NVIDIA updates on repository signing keys

### DIFF
--- a/docker/Dockerfile.atari
+++ b/docker/Dockerfile.atari
@@ -13,17 +13,19 @@
 
 FROM tensorflow/tensorflow:2.4.1-gpu
 
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
 RUN apt-get update && apt-get install -y tmux ffmpeg libsm6 libxext6 libxrender-dev wget unrar unzip
 
 # Install Atari environment
-RUN pip3 install gym[atari]
-RUN pip3 install atari-py
+RUN pip3 install gym[atari]==0.18.0
+RUN pip3 install atari-py opencv-python
 RUN pip3 install tensorflow_probability==0.11.0
 
 RUN mkdir roms && \
     cd roms && \
     wget http://www.atarimania.com/roms/Roms.rar && \
-    unrar e Roms.rar && \
+    unrar -y e Roms.rar && \
     unzip ROMS.zip && \
     unzip "HC ROMS.zip" && \
     rm ROMS.zip && \

--- a/docker/Dockerfile.dmlab
+++ b/docker/Dockerfile.dmlab
@@ -13,6 +13,8 @@
 
 FROM tensorflow/tensorflow:2.4.1-gpu
 
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
 RUN apt-get update && apt-get install -y \
     curl \
     zip \

--- a/docker/Dockerfile.football
+++ b/docker/Dockerfile.football
@@ -16,6 +16,8 @@ FROM tensorflow/tensorflow:2.4.1-gpu
 # Needed to disable interactive configuration by tzdata.
 RUN ln -fs /usr/share/zoneinfo/Europe/Dublin /etc/localtime
 
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
 RUN apt-get update && apt-get install -y \
   git \
   cmake \

--- a/docker/Dockerfile.football
+++ b/docker/Dockerfile.football
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install -y \
   tmux
 
 WORKDIR /
+RUN pip3 install gym==0.19.0
 RUN pip3 install gfootball==2.0.4
 RUN pip3 install tensorflow_probability==0.11.0 dataclasses
 

--- a/docker/Dockerfile.mujoco
+++ b/docker/Dockerfile.mujoco
@@ -13,6 +13,8 @@
 
 FROM tensorflow/tensorflow:2.4.1-gpu
 
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
 RUN apt-get update && apt-get install -y \
     libgl1-mesa-dev \
     libglew-dev \


### PR DESCRIPTION
As NVIDIA has been updating and rotating the signing keys used by the apt, dnf/yum, and zypper package managers since April 27, 2022, the image-building based on existing Dockerfile will fail with the following error:

```bash
$ ./run_local.sh dmlab vtrace 2
Sending build context to Docker daemon  81.55MB
Step 1/10 : FROM tensorflow/tensorflow:2.4.1-gpu
...
Reading package lists...
W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease' is no longer signed.
The command '/bin/bash -c apt-get update && apt-get install -y     curl     zip     unzip     software-properties-common     pkg-config     g++-4.8     zlib1g-dev     lua5.1     liblua5.1-0-dev     libffi-dev     gettext     freeglut3     libsdl2-dev     libosmesa6-dev     libglu1-mesa     libglu1-mesa-dev     python3-dev     build-essential     git     python-setuptools     python3-pip     libjpeg-dev     tmux' returned a non-zero code: 100
$
```

This problem has been official acknowledged as follows,
> ## Working with containers
> CUDA applications built using older NGC base containers may contain outdated repository keys. If you build Docker containers using these images as a base and update the package manager or install additional NVIDIA packages as part of your Dockerfile, these commands may fail as they would on a non-container system. To work around this, integrate the earlier commands into the Dockerfile you use to build the container.
>
> https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key

To fix this, it is suggested to add the following lines to the Dockerfile before `apt-get update`: ([link](https://github.com/NVIDIA/nvidia-docker/issues/1632#issuecomment-1112667716))
```bash
RUN rm /etc/apt/sources.list.d/cuda.list
RUN rm /etc/apt/sources.list.d/nvidia-ml.list
```

Therefore, this PR contains aforementioned revisions on the `Dockerfile.atari`, `Dockerfile.dmlab`, `Dockerfile.football`, and `Dockerfile.mujoco`, which bypasses this problem.